### PR TITLE
Add support for single page applications

### DIFF
--- a/src/mode/direct-embed.ts
+++ b/src/mode/direct-embed.ts
@@ -73,8 +73,8 @@ export class DirectEmbed extends Shared {
   }
 
   /**
-   * Re-initialize the widget when the history api is used or the hash changes.
-   * This is necessary to support single page applications
+   * Re-initialize the widget when the history api is used, the back button is clicked,
+   * or the hash changes. This is necessary to support single page applications
    */
   private reInitializeOnRouteChange() {
     const { pushState, replaceState } = history;


### PR DESCRIPTION
The widget must be re-initialized when the page of a single page application changes and the widget is in `direct-embed` mode.

Unfortunately, some monkey patching is necessary when the page is changed using the History API because there's no `onpushstate` or `onreplacestate`.